### PR TITLE
update virtualenv command

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Project Structure
 
 2. Initialize and activate a virtualenv:
   ```
-  $ virtualenv --no-site-packages env
+  $ virtualenv env
   $ source env/bin/activate
   ```
 


### PR DESCRIPTION
The argument --no-site-packages is deprecated and is now the default behavior according to the --help.
https://virtualenv.pypa.io/en/stable/reference/