### PR TITLE
Updated PythonAnywhere virtualenv instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,14 +203,7 @@ Deploying to Heroku
 8. Click the "Add a new web app" link on the left; by default this will create an app at your-username.pythonanywhere.com, though if you've signed up for a paid "Web Developer" account you can also specify your own domain name here. Once you've decided on the location of the app, click the "Next" button.
 9. On the next page, click the "Flask" option, and on the next page just keep the default settings and click "Next" again.
 Once the web app has been created (it'll take 20 seconds or so), you'll see a link near the top of the page, under the "Reload web app" button, saying "It is configured via a WSGI file stored at..." and a filename.  Click this, and you get to a page with a text editor.
-10. Put the following lines of code at the start of the WSGI file (changing "your-username" appropriately)
-
-  ```
-  activate_this = '/home/your-username/flask-boilerplate/venv/bin/activate_this.py'
-  execfile(activate_this, dict(__file__=activate_this))
-  ```
-
-11. Then update the following lines of code:
+10. Then update the following lines of code:
 
   from
 
@@ -236,8 +229,10 @@ Once the web app has been created (it'll take 20 seconds or so), you'll see a li
   from app import app as application
   ```
 
-12. Save the file.
-13. Go to the website http://your-username.pythonanywhere.com/ (or your own domain if you specified a different one earlier), and you should see something like this - [http://www.flaskboilerplate.com/](http://www.flaskboilerplate.com/).
+11. Save the file.
+12. Back on the Web tab, scroll down to the "Virtualenv" section, and click on the "Enter path to a virtualenv, if required" link.  In the input that pops up, enter `/home/your-username/flask-boilerplate/venv` (changing "your-username" appropriately) and hit return.
+13. Click the green "Reload" button at the top of the page.
+14. Go to the website http://your-username.pythonanywhere.com/ (or your own domain if you specified a different one earlier), and you should see something like this - [http://www.flaskboilerplate.com/](http://www.flaskboilerplate.com/).
 
 *Now you're ready to start developing!*
 


### PR DESCRIPTION
I appreciate that this is an old project and perhaps isn't being updated :-)

However, on tech support for PythonAnywhere we've had an uptick in people using LLMs to guide them through the Flask deployment process, and one problem they keep tripping over is that they're using `activate_this` in their WSGI files, which was the pattern we recommended back in the day, and is documented in lots of places, including here.  Unfortunately now it causes more problems than it solves.

We've been scouring the Internet for mentions to see if we can change this so that the next training runs know the up-to-date way to do this, and would really appreciate it if this could be merged.